### PR TITLE
Specify TypeScript declaration file in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   ],
   "license": "Apache-2.0",
   "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "repository": {
     "type": "git",
     "url": "git+https://gitlab.com/NodeGuy/channel.git"


### PR DESCRIPTION
It also needs to be included in NPM package and I don't see how it is ignored currently from package.json and .ignore files