### PR TITLE
Possible heap overflow: Cancelled orders are not removed

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -104,6 +104,20 @@ const Channel = function(length = 0) {
 
     pushes.splice(0, index.push);
     shifts.splice(0, index.shift);
+
+    // Remove cancelled pushes
+    for (let i = pushes.length - 1; i >= 0; i--) {
+      if (pushes[i].cancelled) {
+        pushes.splice(i, 1);
+      }
+    }
+
+    // Remove cancelled shifts
+    for (let i = shifts.length - 1; i >= 0; i--) {
+      if (shifts[i].cancelled) {
+        shifts.splice(i, 1);
+      }
+    }
   };
 
   const readOnly = Object.freeze(


### PR DESCRIPTION
Issue:
The following code generates a heap overflow:

```typescript
import Channel from "@nodeguy/channel";

async function heapTest() {
    const closedDefault = new Channel<{}>();
    closedDefault.close();
    const randomOtherChannel = new Channel<{}>();

    while (true) {
        switch (await Channel.select([randomOtherChannel.push({}), closedDefault.shift()])) {
            case randomOtherChannel:
                // Will never happen
                throw new Error();
            default:
                // Will always happen
                break;
        }
    }
}

heapTest();
```

Why:
Every iteration of the while loop appends a new `order` object to the `pushes` array of `randomOtherChannel`. The `order` immediately get’s cancelled but is never removed from the array. It should normally be skipped inside `matchPushesAndShifts()` and then sliced off inside `processOrders()`. This never happens because the while loop condition inside `matchPushesAndShifts()` is never met (the `shifts` array of `randomOtherChannel` is always empty).

Solution:
Filter out all cancelled orders from `pushes` and `shifts` at the end of every `processOrders()` call.

